### PR TITLE
Make PAPI expansion persist across reloads

### DIFF
--- a/bukkit/src/main/java/net/craftingstore/bukkit/hooks/PlaceholderAPIHook.java
+++ b/bukkit/src/main/java/net/craftingstore/bukkit/hooks/PlaceholderAPIHook.java
@@ -101,4 +101,9 @@ public class PlaceholderAPIHook extends PlaceholderExpansion {
     public String getVersion() {
         return this.instance.getImplementation().getConfiguration().getVersion();
     }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
 }


### PR DESCRIPTION
Currently `/papi reload` will remove the CraftingStore expansion from the list of loaded expansions. Stupid default, but needs to be fixed nonetheless.