### PR TITLE
Bump xseries version to fix buy menu on Spigot 26

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>com.github.cryptomorin</groupId>
             <artifactId>XSeries</artifactId>
-            <version>9.4.0</version>
+            <version>13.7.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.MilkBowl</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <revision>${craftingstore-version}-RELEASE</revision>
-        <craftingstore-version>2.11.2</craftingstore-version>
+        <craftingstore-version>2.11.3</craftingstore-version>
     </properties>
 
     <build>


### PR DESCRIPTION
Fix /buy menu not working on Spigot 26.

Based on: https://github.com/CraftingStore/MinecraftPlugin/pull/32 but do not bump paper-api version.